### PR TITLE
feat: replace GithubIcon URL with current repo URL (#5)

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -32,7 +32,8 @@ useSeoMeta({
     <UHeader>
       <template #left>
         <NuxtLink to="/">
-          <LogoPro class="w-auto h-6 shrink-0" />
+          
+           <img src="https://avatars.githubusercontent.com/u/189975276?s=200&v=4" class="w-auto h-6 shrink-0 w-10 h-10 bg-gray-200" />
         </NuxtLink>
 
         <TemplateMenu />
@@ -42,7 +43,7 @@ useSeoMeta({
         <UColorModeButton />
 
         <UButton
-          to="https://github.com/nuxt-ui-pro/starter"
+          to="https://github.com/edumapper/cycling"
           target="_blank"
           icon="i-simple-icons-github"
           aria-label="GitHub"


### PR DESCRIPTION
# feat: replace GithubIcon URL with current repo URL (#5)

## Context 
J’ai remarqué que mes précédentes branches comportaient trop de modifications empilées, ce qui rendait la relecture des PR peu lisible.

## modification 
### Remise à plat de la branche 
 * Création de branches propre ```(feat/update-githubicon-url-5-clean)``` à partir de develop pour chaque issue ( là en l'occurence pour l'issue 5 ), afin d’isoler chaque commit.
 * Utilisation de ```git cherry-pick``` / ```git rebase --onto``` pour ne reprendre que les commits pertinents à chaque issue.

### Mise à jour du code
* remplacement de l’URL du composant GithubIcon par l’URL du repo privé (via variable d’environnement ou hardcodée).
<img width="934" alt="Capture d’écran 2025-05-01 à 13 11 55" src="https://github.com/user-attachments/assets/6a947cce-398e-4290-a00a-df4f95445c26" />

### Nettoyage
* l'idée est de refaire la même manoeuvre pour toutes les autres branches et ensuite supprimer les anciennes :) 

### Resultat attendu 
* Un historique Git clair, chaque PR ne portant que les changements liés à une seule issue.
* Des branches créées systématiquement depuis develop pour éviter toute dépendance croisée.
* Une configuration Git locale désormais correctement paramétrée.
