### PR TITLE
feat: add privacy policy content sections (#2)

### DIFF
--- a/app/components/PrivacySidebar.vue
+++ b/app/components/PrivacySidebar.vue
@@ -1,0 +1,32 @@
+<template>
+  <nav class="w-64 p-4 bg-gray-50/80 backdrop-blur-sm fixed top-0 left-0 h-screen hidden md:block border-r border-gray-100 z-10">
+    <ul class="space-y-2">
+      <li v-for="sec in sections" :key="sec.id">
+        <a 
+          :href="`#${sec.id}`" 
+          class="block px-4 py-2 text-gray-600 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition-all duration-200"
+          @click="handleClick"
+        >
+          {{ sec.title }}
+        </a>
+      </li>
+    </ul>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import { sections } from '@/layout/privacy-policy';
+
+const handleClick = (e: MouseEvent) => {
+  e.preventDefault();
+  const target = e.target as HTMLAnchorElement;
+  const id = target.getAttribute('href')?.replace('#', '');
+  if (id) {
+    const element = document.getElementById(id);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth' });
+    }
+  }
+};
+</script>
+  

--- a/app/layout/privacy-policy.ts
+++ b/app/layout/privacy-policy.ts
@@ -1,0 +1,55 @@
+export interface Section {
+    id: string;
+    title: string;
+    text: string;
+  }
+  
+  export const sections: Section[] = [
+    {
+      id: 'intro',
+      title: 'Introduction',
+      text: 'Chez Cycling, nous nous engageons à protéger la confidentialité et la sécurité de vos données personnelles. Cette politique de confidentialité explique comment nous collectons, utilisons, partageons et protégeons les informations personnelles que vous nous fournissez lorsque vous utilisez notre site web, nos applications ou nos services.'
+    },
+    {
+      id: 'collection',
+      title: 'Collecte des Informations',
+      text: 'Informations Personnelles\n\nIdentité : Nom, prénom, adresse e-mail, numéro de téléphone, adresse postale.\nInformations de compte : Nom d’utilisateur, mot de passe, informations de profil.\nInformations de paiement : Numéro de carte de crédit, informations bancaires (si applicable).\n\nInformations de Navigation\n\nAdresse IP : Pour déterminer votre localisation géographique.\nType de navigateur et système d’exploitation : Pour optimiser l’affichage et les performances.\nPages consultées et interactions : Pour améliorer l’expérience utilisateur et personnaliser le contenu.\n\nCookies et Technologies Similaires\n\nNous utilisons des cookies et des technologies similaires pour analyser le trafic, personnaliser le contenu et proposer des publicités ciblées en fonction de vos intérêts.'
+    },
+    {
+      id: 'utilisation',
+      title: 'Utilisation des Informations',
+      text: 'Nous utilisons vos informations personnelles pour créer et gérer votre compte utilisateur, traiter vos commandes et transactions, et vous fournir un support client.\n\nNous analysons également vos données pour améliorer nos produits et services, développer de nouvelles fonctionnalités, et personnaliser votre expérience utilisateur.\n\nEnfin, nous utilisons vos informations pour vous envoyer des newsletters et des offres promotionnelles, vous informer des mises à jour importantes concernant nos services, et répondre à vos demandes et questions.'
+    },
+    {
+      id: 'partage',
+      title: 'Partage des Informations',
+      text: 'Partenaires Commerciaux : Nous pouvons partager vos informations avec nos partenaires commerciaux pour fournir des services conjoints et vous proposer des offres et promotions.\nPrestataires de Services : Nous partageons vos informations avec des prestataires de services tiers pour héberger notre site web, traiter les paiements, et fournir un support technique.\nObligations Légales : Nous pouvons divulguer vos informations personnelles si nous sommes légalement tenus de le faire, par exemple en réponse à une demande des autorités compétentes, pour protéger nos droits et notre propriété, ou assurer la sécurité de nos utilisateurs.'
+    },
+    {
+      id: 'securite',
+      title: 'Sécurité des Données',
+      text: 'Nous mettons en œuvre des mesures de sécurité techniques et organisationnelles pour protéger vos informations personnelles contre l’accès non autorisé, la divulgation ou destruction accidentelle, et les altérations non autorisées.\n\nVos informations personnelles sont stockées sur des serveurs sécurisés et sont conservées aussi longtemps que nécessaire pour les finalités décrites dans cette politique.'
+    },
+    {
+      id: 'droits',
+      title: 'Vos Droits',
+      text: 'Accès et Rectification : Vous avez le droit d’accéder à vos informations personnelles et de demander la correction ou la mise à jour de vos informations.\nSuppression : Vous pouvez demander la suppression de vos informations personnelles si elles ne sont plus nécessaires aux finalités pour lesquelles elles ont été collectées ou si vous retirez votre consentement lorsque le traitement est basé sur le consentement.\nOpposition : Vous avez le droit de vous opposer au traitement de vos informations personnelles pour des raisons légitimes.'
+    },
+    {
+      id: 'modifications',
+      title: 'Modifications de la Politique de Confidentialité',
+      text: 'Nous nous réservons le droit de modifier cette politique de confidentialité à tout moment. Les modifications seront publiées sur cette page avec la date de la dernière mise à jour. Nous vous encourageons à consulter régulièrement cette page pour rester informé de nos pratiques en matière de confidentialité.'
+    },
+    {
+      id: 'contact',
+      title: 'Contact',
+      text: 'Pour toute question ou demande concernant notre politique de confidentialité, veuillez nous contacter à [adresse e-mail de contact] ou par courrier à [adresse postale de contact].'
+    },
+    {
+      id: 'update',
+      title: 'Dernière mise à jour',
+      text: '29/04/2025'
+    }
+  ];
+  
+  

--- a/app/pages/privacy-policy.vue
+++ b/app/pages/privacy-policy.vue
@@ -1,6 +1,25 @@
 <template>
-  <div class="prose mx-auto py-12">
-    <h1>Privacy Policy</h1>
-    <p>This is the Privacy Policy page.</p>
+  <div class="flex">
+    <PrivacySidebar />
+
+    <main class="flex-1 p-8 md:ml-64">
+      <h1 class="text-3xl font-bold mb-6">Politique de confidentialité</h1>
+
+      <section
+        v-for="sec in sections"
+        :key="sec.id"
+        :id="sec.id"
+        class="mb-8 scroll-mt-20"
+      >
+        <h2 class="text-2xl font-semibold mb-2">{{ sec.title }}</h2>
+        <p>{{ sec.text }}</p>
+      </section>
+    </main>
   </div>
 </template>
+
+<script setup lang="ts">
+import PrivacySidebar from '@/components/PrivacySidebar.vue';
+import { sections } from '@/layout/privacy-policy';
+</script>
+


### PR DESCRIPTION
# Amélioration du layout de la page de politique de confidentialité

## Changements effectués
- Implémentation d'une sidebar fixe avec défilement fluide
- Création d'un contraste visuel subtil avec le contenu principal
- Optimisation du layout pour une meilleure expérience utilisateur

## Détails techniques
- Sidebar fixe avec position `fixed` et hauteur complète (`h-screen`)
- Fond semi-transparent avec effet de flou (`backdrop-blur-sm`)
- Défilement fluide vers les sections avec `scrollIntoView`
- Marge appropriée pour le contenu principal (`md:ml-64`)
- Transitions douces sur les interactions utilisateur

## Objectif
Améliorer la navigation et l'expérience utilisateur sur la page de politique de confidentialité en :
- Gardant la navigation toujours visible
- Facilitant l'accès aux différentes sections
- Créant une interface élégante et professionnelle

## Impact
- Navigation plus intuitive et accessible
- Meilleure lisibilité du contenu
- Interface plus moderne et professionnelle